### PR TITLE
provide async implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "henrikbjorn/phpspec-code-coverage" : "^1.0"
     },
     "provide": {
+        "php-http/async-client-implementation": "1.0",
         "php-http/client-implementation": "1.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no

#### What's in this PR?

Provided a `async-client-implementation`


#### Why?

As a library developer I needed the mock client to provide an `async-client-implementation` via Composer, it implemented the inteface but never specified that in Composer.

Without this, Composer would complain because there was no concrete async client available to satify my library pre-implementation. (as I'm only using the mock-client in my require-dev).