### PR TITLE
Fix the min version for client-common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
-        "php-http/client-common": "^1.0",
+        "php-http/client-common": "^1.1",
         "php-http/discovery": "^1.0",
         "php-http/message-factory": "^1.0"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

The 1.0 release does not depend on the php-http/message and so does not bring the message factories, making testing painful

#### Why?

The goal is to make it less painful for projects running a `--prefer-lowest` job on CI (avoiding to add a requirement on php-http/message themselves)

