### PR TITLE
Implement default response and exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Added
+
+- Default response functionality
+- Default exception functionality
 
 ## 1.0.1 - 2017-05-02
 

--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -36,9 +36,23 @@ class ClientSpec extends ObjectBehavior
         $this->sendRequest($request)->shouldReturn($response);
     }
 
+    function it_returns_the_default_response_for_a_request(RequestInterface $request, ResponseInterface $response)
+    {
+        $this->setDefaultResponse($response);
+
+        $this->sendRequest($request)->shouldReturn($response);
+    }
+
     function it_throws_an_exception_for_a_request(RequestInterface $request)
     {
         $this->addException(new \Exception());
+
+        $this->shouldThrow('Exception')->duringSendRequest($request);
+    }
+
+    function it_throws_the_default_exception_for_a_request(RequestInterface $request)
+    {
+        $this->setDefaultException(new \Exception());
 
         $this->shouldThrow('Exception')->duringSendRequest($request);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,9 +40,19 @@ class Client implements HttpClient, HttpAsyncClient
     private $responses = [];
 
     /**
+     * @var ResponseInterface|null
+     */
+    private $defaultResponse;
+
+    /**
      * @var Exception[]
      */
     private $exceptions = [];
+
+    /**
+     * @var Exception|null
+     */
+    private $defaultException;
 
     /**
      * @param ResponseFactory|null $responseFactory
@@ -67,6 +77,14 @@ class Client implements HttpClient, HttpAsyncClient
             return array_shift($this->responses);
         }
 
+        if ($this->defaultException) {
+            throw $this->defaultException;
+        }
+
+        if ($this->defaultResponse) {
+            return $this->defaultResponse;
+        }
+
         // Return success response by default
         return $this->responseFactory->createResponse();
     }
@@ -82,6 +100,18 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /**
+     * Sets the default exception to throw when the list of added exceptions and responses is exhausted.
+     *
+     * If both a default exception and a default response are set, the exception will be thrown.
+     *
+     * @param \Exception|null $defaultException
+     */
+    public function setDefaultException(\Exception $defaultException = null)
+    {
+        $this->defaultException = $defaultException;
+    }
+
+    /**
      * Adds a response that will be returned.
      *
      * @param ResponseInterface $response
@@ -89,6 +119,16 @@ class Client implements HttpClient, HttpAsyncClient
     public function addResponse(ResponseInterface $response)
     {
         $this->responses[] = $response;
+    }
+
+    /**
+     * Sets the default response to be returned when the list of added exceptions and responses is exhausted.
+     *
+     * @param ResponseInterface|null $defaultResponse
+     */
+    public function setDefaultResponse(ResponseInterface $defaultResponse = null)
+    {
+        $this->defaultResponse = $defaultResponse;
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #20 as an alternative
| Documentation   | https://github.com/php-http/documentation/pull/212
| License         | MIT


#### What's in this PR?

It allows to set a default response or exception if we don't care about what to returns but can't return an empty one.

#### Why?

This implements an idea from @dbu (https://github.com/php-http/mock-client/issues/3#issuecomment-243749012).

But this is a partial resolution of #3 only.

#### Example Usage

See the documentation PR.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
