### PR TITLE
Add Client::getLastRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Default response functionality
 - Default exception functionality
+- `getLastRequest` method
 
 ## 1.0.1 - 2017-05-02
 

--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -66,4 +66,11 @@ class ClientSpec extends ObjectBehavior
 
         $this->sendRequest($request)->shouldReturn($response);
     }
+
+    function it_returns_the_last_request(RequestInterface $request)
+    {
+        $this->sendRequest($request);
+
+        $this->getLastRequest()->shouldReturn($request);
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -140,4 +140,12 @@ class Client implements HttpClient, HttpAsyncClient
     {
         return $this->requests;
     }
+
+    /**
+     * @return RequestInterface|false
+     */
+    public function getLastRequest()
+    {
+        return end($this->requests);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #16
| Documentation   | https://github.com/php-http/documentation/pull/213
| License         | MIT


#### What's in this PR?

Add getters for last response, exception and request.

#### Why?

Because @sagikazarmark asked for it. :wink: 

#### Example Usage

See the doc PR

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
