### PR TITLE
Allow to easily extend the Mock client.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -4,8 +4,6 @@ namespace Http\Mock;
 
 use Http\Client\Common\HttpAsyncClientEmulator;
 use Http\Client\Exception;
-use Http\Client\HttpAsyncClient;
-use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\ResponseFactory;
 use Psr\Http\Message\RequestInterface;
@@ -20,39 +18,39 @@ use Psr\Http\Message\ResponseInterface;
  *
  * @author David de Boer <david@ddeboer.nl>
  */
-class Client implements HttpClient, HttpAsyncClient
+class Client implements ClientInterface
 {
     use HttpAsyncClientEmulator;
 
     /**
      * @var ResponseFactory
      */
-    private $responseFactory;
+    protected $responseFactory;
 
     /**
      * @var RequestInterface[]
      */
-    private $requests = [];
+    protected $requests = [];
 
     /**
      * @var ResponseInterface[]
      */
-    private $responses = [];
+    protected $responses = [];
 
     /**
      * @var ResponseInterface|null
      */
-    private $defaultResponse;
+    protected $defaultResponse;
 
     /**
      * @var Exception[]
      */
-    private $exceptions = [];
+    protected $exceptions = [];
 
     /**
      * @var Exception|null
      */
-    private $defaultException;
+    protected $defaultException;
 
     /**
      * @param ResponseFactory|null $responseFactory
@@ -90,9 +88,7 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /**
-     * Adds an exception that will be thrown.
-     *
-     * @param \Exception $exception
+     * {@inheritdoc}
      */
     public function addException(\Exception $exception)
     {
@@ -100,11 +96,7 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /**
-     * Sets the default exception to throw when the list of added exceptions and responses is exhausted.
-     *
-     * If both a default exception and a default response are set, the exception will be thrown.
-     *
-     * @param \Exception|null $defaultException
+     * {@inheritdoc}
      */
     public function setDefaultException(\Exception $defaultException = null)
     {
@@ -112,9 +104,7 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /**
-     * Adds a response that will be returned.
-     *
-     * @param ResponseInterface $response
+     * {@inheritdoc}
      */
     public function addResponse(ResponseInterface $response)
     {
@@ -122,9 +112,7 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /**
-     * Sets the default response to be returned when the list of added exceptions and responses is exhausted.
-     *
-     * @param ResponseInterface|null $defaultResponse
+     * {@inheritdoc}
      */
     public function setDefaultResponse(ResponseInterface $defaultResponse = null)
     {
@@ -132,9 +120,7 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /**
-     * Returns requests that were sent.
-     *
-     * @return RequestInterface[]
+     * {@inheritdoc}
      */
     public function getRequests()
     {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Http\Mock;
+
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * HTTP Mock Client interface.
+ *
+ * @author Dezső Biczó <mxr576@gmail.com>
+ */
+interface ClientInterface extends HttpClient, HttpAsyncClient
+{
+    /**
+     * Adds an exception that will be thrown.
+     *
+     * @param \Exception $exception
+     */
+    public function addException(\Exception $exception);
+
+    /**
+     * Sets the default exception to throw when the list of added exceptions and responses is exhausted.
+     *
+     * If both a default exception and a default response are set, the exception will be thrown.
+     *
+     * @param \Exception|null $defaultException
+     */
+    public function setDefaultException(\Exception $defaultException = null);
+
+    /**
+     * Adds a response that will be returned.
+     *
+     * @param ResponseInterface $response
+     */
+    public function addResponse(ResponseInterface $response);
+
+    /**
+     * Sets the default response to be returned when the list of added exceptions and responses is exhausted.
+     *
+     * @param ResponseInterface|null $defaultResponse
+     */
+    public function setDefaultResponse(ResponseInterface $defaultResponse = null);
+
+    /**
+     * Returns requests that were sent.
+     *
+     * @return RequestInterface[]
+     */
+    public function getRequests();
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

This PR allows the extension of the Mock client.

#### Why?

I have tried to extend the Mock client with some custom logic but I was unable to do that because all properties of the class are private. Also, I think introducing an interface that describes the public methods of the mock client could be useful for the future.

#### Example Usage

#### Checklist

- [ ] Updated CHANGELOG.md to describe new feature

#### To Do
