### PR TITLE
Implement reset

### DIFF
--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -84,4 +84,26 @@ class ClientSpec extends ObjectBehavior
     {
         $this->getLastRequest()->shouldReturn(false);
     }
+
+    function it_reset(
+        ResponseFactory $responseFactory,
+        RequestInterface $request,
+        ResponseInterface $response,
+        ResponseInterface $newResponse
+    ) {
+        $this->addResponse($response);
+        $this->setDefaultResponse($response);
+        $this->addException(new \Exception());
+        $this->setDefaultException(new \Exception());
+
+        $responseFactory->createResponse()->willReturn($newResponse);
+
+        $this->reset();
+
+        $this->sendRequest($request)->shouldReturn($newResponse);
+
+        $this->reset();
+
+        $this->getRequests()->shouldReturn([]);
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -135,4 +135,13 @@ class Client implements HttpClient, HttpAsyncClient
     {
         return end($this->requests);
     }
+
+    public function reset()
+    {
+        $this->responses = [];
+        $this->exceptions = [];
+        $this->requests = [];
+        $this->setDefaultException();
+        $this->setDefaultResponse();
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   |
| License         | MIT


#### What's in this PR?

Add the possiblity to reset the client


#### Why?

To avoid side effects when using the mock on multiple tests


#### Example Usage

``` php
$client = new Client();

$response = $this->createMock('Psr\Http\Message\ResponseInterface');
$client->addResponse($response);

$client->reset();
// responses and exceptions stacks are empty now
```


#### To Do

- [ ] Documentation needed ?
