### PR TITLE
Add conditional responses to mock client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.2.1 - 2019-02-20
+
+### Added
+
+- Conditional mock functionality
+
 ## 1.2.0 - 2019-01-19
 
 ### Added

--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -4,6 +4,7 @@ namespace spec\Http\Mock;
 
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Http\Message\RequestMatcher;
 use Http\Message\ResponseFactory;
 use Http\Mock\Client;
 use Psr\Http\Message\RequestInterface;
@@ -90,7 +91,8 @@ class ClientSpec extends ObjectBehavior
         RequestInterface $request,
         ResponseInterface $response,
         ResponseInterface $newResponse
-    ) {
+    )
+    {
         $this->addResponse($response);
         $this->setDefaultResponse($response);
         $this->addException(new \Exception());
@@ -105,5 +107,54 @@ class ClientSpec extends ObjectBehavior
         $this->reset();
 
         $this->getRequests()->shouldReturn([]);
+    }
+    function it_returns_response_if_request_matcher_matches(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
+        $matcher->matches($request)->willReturn(true);
+        $this->on($matcher, $response);
+        $this->sendRequest($request)->shouldReturn($response);
+    }
+
+    function it_throws_exception_if_request_matcher_matches(
+        RequestMatcher $matcher,
+        RequestInterface $request
+    ) {
+        $matcher->matches($request)->willReturn(true);
+        $this->on($matcher, new \Exception());
+        $this->shouldThrow('Exception')->duringSendRequest($request);
+    }
+
+    function it_skips_conditional_response_if_matcher_returns_false(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $expectedResponse,
+        ResponseInterface $skippedResponse
+    )
+    {
+        $matcher->matches($request)->willReturn(false);
+        $this->on($matcher, $skippedResponse);
+        $this->addResponse($expectedResponse);
+        $this->sendRequest($request)->shouldReturn($expectedResponse);
+    }
+
+    function it_calls_callable_with_request_as_argument_when_matcher_returns_true(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $response
+    )
+    {
+        $matcher->matches($request)->willReturn(true);
+
+        $this->on(
+            $matcher,
+            function(RequestInterface $request) use ($response) {
+                return $response->getWrappedObject();
+            }
+        );
+
+        $this->sendRequest($request)->shouldReturn($response);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -107,6 +107,10 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /**
+     * Adds an exception to be thrown or response to be returned if the request matcher matches.
+     *
+     * For more complex logic, pass a callable which should take the request and return a response or exception
+     *
      * @param RequestMatcher                        $requestMatcher
      * @param ResponseInterface|\Exception|callable $result
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -78,7 +78,7 @@ class Client implements HttpClient, HttpAsyncClient
             $callable = $result['callable'];
 
             /**
-             * @var RequestMatcher $matcher
+             * @var $matcher RequestMatcher
              * @var ResponseInterface|Exception $result
              */
             if ($matcher->matches($request)) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | discussed in #3
| Documentation   | Not written yet
| License         | MIT


#### What's in this PR?

Following discussions at https://github.com/php-http/mock-client/issues/3 this adds
a on method taking a RequestMatcher and then either a Response, an Exception or a
callable.

This allows for mock clients to not depend on the order the responses/exceptions
are mocked.

It also allows for responses to depend on some content in the request, avoiding
duplication in some cases.

#### Example Usage

Aside from the usage discussed in the linked issue, the callable allows for repeated similar responses to be mocked at once, like this:

``` php
$mock->on(
  new RequestMatcher('#widgets/[0-9]+#'),
  function(RequestInterface $request) {
    return $this->messageFactory->createResponse()->withBodyBasedOffIdInURL();
  }
)
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

