### PR TITLE
WIP: upgrade to HTTPlug 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - 7.3
@@ -25,7 +22,7 @@ branches:
 matrix:
     fast_finish: true
     include:
-        - php: 5.5
+        - php: 7.1
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.0.0 - unreleased
+
+### Changed
+
+- Client::getLastRequest returns `null` instead of `false` when on requests have been recorded yet.
+
 ## 1.1.0 - 2018-01-08
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
-        "php-http/httplug": "^1.0",
-        "php-http/client-common": "^1.1 || ^2.0",
+        "php": "^7.1",
+        "php-http/httplug": "^2.0",
+        "php-http/client-common": "^2.0",
         "php-http/discovery": "^1.0",
         "php-http/message-factory": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "2.0.x-dev"
         }
     },
     "prefer-stable": true,

--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Http\Mock;
 
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
 use Http\Message\ResponseFactory;
+use Http\Mock\Client;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
@@ -16,17 +19,17 @@ class ClientSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Http\Mock\Client');
+        $this->shouldHaveType(Client::class);
     }
 
     function it_is_an_http_client()
     {
-        $this->shouldImplement('Http\Client\HttpClient');
+        $this->shouldImplement(HttpClient::class);
     }
 
     function it_is_an_async_http_client()
     {
-        $this->shouldImplement('Http\Client\HttpAsyncClient');
+        $this->shouldImplement(HttpAsyncClient::class);
     }
 
     function it_returns_a_response_for_a_request(RequestInterface $request, ResponseInterface $response)
@@ -67,10 +70,18 @@ class ClientSpec extends ObjectBehavior
         $this->sendRequest($request)->shouldReturn($response);
     }
 
-    function it_returns_the_last_request(RequestInterface $request)
+    function it_returns_the_last_request(RequestInterface $request, ResponseInterface $response)
     {
+        // we need to set something that sendRequest can return.
+        $this->addResponse($response);
+
         $this->sendRequest($request);
 
         $this->getLastRequest()->shouldReturn($request);
+    }
+
+    function it_returns_null_when_there_is_no_last_request()
+    {
+        $this->getLastRequest()->shouldReturn(null);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,11 +12,10 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * HTTP client mock.
+ * An implementation of the HTTP client that is useful for automated tests.
  *
- * This mock is most useful in tests. It does not send requests but stores them
- * for later retrieval. Additionally, you can set an exception to test
- * exception handling.
+ * This mock does not send requests but stores them for later retrieval.
+ * You can configure the mock with responses to return and/or exceptions to throw.
  *
  * @author David de Boer <david@ddeboer.nl>
  */
@@ -54,9 +53,6 @@ class Client implements HttpClient, HttpAsyncClient
      */
     private $defaultException;
 
-    /**
-     * @param ResponseFactory|null $responseFactory
-     */
     public function __construct(ResponseFactory $responseFactory = null)
     {
         $this->responseFactory = $responseFactory ?: MessageFactoryDiscovery::find();
@@ -65,7 +61,7 @@ class Client implements HttpClient, HttpAsyncClient
     /**
      * {@inheritdoc}
      */
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         $this->requests[] = $request;
 
@@ -91,8 +87,6 @@ class Client implements HttpClient, HttpAsyncClient
 
     /**
      * Adds an exception that will be thrown.
-     *
-     * @param \Exception $exception
      */
     public function addException(\Exception $exception)
     {
@@ -103,18 +97,14 @@ class Client implements HttpClient, HttpAsyncClient
      * Sets the default exception to throw when the list of added exceptions and responses is exhausted.
      *
      * If both a default exception and a default response are set, the exception will be thrown.
-     *
-     * @param \Exception|null $defaultException
      */
-    public function setDefaultException(\Exception $defaultException = null)
+    public function setDefaultException(?\Exception $defaultException)
     {
         $this->defaultException = $defaultException;
     }
 
     /**
-     * Adds a response that will be returned.
-     *
-     * @param ResponseInterface $response
+     * Adds a response that will be returned in first in first out order.
      */
     public function addResponse(ResponseInterface $response)
     {
@@ -123,10 +113,8 @@ class Client implements HttpClient, HttpAsyncClient
 
     /**
      * Sets the default response to be returned when the list of added exceptions and responses is exhausted.
-     *
-     * @param ResponseInterface|null $defaultResponse
      */
-    public function setDefaultResponse(ResponseInterface $defaultResponse = null)
+    public function setDefaultResponse(?ResponseInterface $defaultResponse)
     {
         $this->defaultResponse = $defaultResponse;
     }
@@ -136,16 +124,13 @@ class Client implements HttpClient, HttpAsyncClient
      *
      * @return RequestInterface[]
      */
-    public function getRequests()
+    public function getRequests(): array
     {
         return $this->requests;
     }
 
-    /**
-     * @return RequestInterface|false
-     */
-    public function getLastRequest()
+    public function getLastRequest(): ?RequestInterface
     {
-        return end($this->requests);
+        return end($this->requests) ?: null;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Upgrade to Httplug 2.0. There is no point in changing this to be a PSR-18 mock client, because this also implements the async client.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- no documentation changes needed

#### To Do

- [ ] Use stable client-common 2.0 once released.