### PR TITLE
drop hhvm test as hhvm diverged and no longer works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
 
 env:
     global:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Stop testing with hhvm.


#### Why?

Tests with hhvm started failing without changes from our side. hhvm is not used much these days, so i vote for dropping that build.

