### PR TITLE
WIP: Start version 2 with some cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.0.0 - unreleased
+
+### Changed
+
+- Client::getLastRequest returns `null` instead of `false` when on requests have been recorded yet.
+
 ## 1.5.0 - 2021-08-25
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "autoload": {

--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -82,9 +82,9 @@ class ClientSpec extends ObjectBehavior
         $this->getLastRequest()->shouldReturn($request);
     }
 
-    function it_returns_false_when_there_is_no_last_request()
+    function it_returns_null_when_there_is_no_last_request()
     {
-        $this->getLastRequest()->shouldReturn(false);
+        $this->getLastRequest()->shouldReturn(null);
     }
 
     function it_reset(

--- a/src/Client.php
+++ b/src/Client.php
@@ -188,7 +188,7 @@ class Client implements HttpClient, HttpAsyncClient
      *
      * If both a default exception and a default response are set, the exception will be thrown.
      */
-    public function setDefaultException(\Exception $defaultException = null)
+    public function setDefaultException(?\Exception $defaultException)
     {
         if (null !== $defaultException && !$defaultException instanceof Exception) {
             @trigger_error('Clients may only throw exceptions of type '.Exception::class.'. Setting an exception of class '.get_class($defaultException).' will not be possible anymore in the future', E_USER_DEPRECATED);
@@ -207,7 +207,7 @@ class Client implements HttpClient, HttpAsyncClient
     /**
      * Sets the default response to be returned when the list of added exceptions and responses is exhausted.
      */
-    public function setDefaultResponse(ResponseInterface $defaultResponse = null)
+    public function setDefaultResponse(?ResponseInterface $defaultResponse)
     {
         $this->defaultResponse = $defaultResponse;
     }
@@ -217,14 +217,14 @@ class Client implements HttpClient, HttpAsyncClient
      *
      * @return RequestInterface[]
      */
-    public function getRequests()
+    public function getRequests(): array
     {
         return $this->requests;
     }
 
-    public function getLastRequest()
+    public function getLastRequest(): ?RequestInterface
     {
-        return end($this->requests);
+        return end($this->requests) ?: null;
     }
 
     public function reset()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | BC breaking changes from #29
| Documentation   | -
| License         | MIT


#### What's in this PR?

Some BC breaking changes that clean up the mock client. To be merged when we want to start with version 2.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- no documentation changes needed

#### TODO

- [ ] Use PSR response factory instead of httplug factory
- [ ] Only allow PSR-18 and httplug exceptions to be configured on the mock client
- [ ] Bump to version 2 of httplug and provide psr/http-client-implementation to fix #38