### PR TITLE
clients may only throw http exceptions, deprecate configuring other e…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -92,6 +92,9 @@ class Client implements HttpClient, HttpAsyncClient
      */
     public function addException(\Exception $exception)
     {
+        if (!$exception instanceof Exception) {
+            @trigger_error('Clients may only throw exceptions of type '.Exception::class.'. Setting an exception of class '.get_class($exception).' will not be possible anymore in the future', E_USER_DEPRECATED);
+        }
         $this->exceptions[] = $exception;
     }
 
@@ -102,6 +105,9 @@ class Client implements HttpClient, HttpAsyncClient
      */
     public function setDefaultException(\Exception $defaultException = null)
     {
+        if (!$defaultException instanceof Exception) {
+            @trigger_error('Clients may only throw exceptions of type '.Exception::class.'. Setting an exception of class '.get_class($defaultException).' will not be possible anymore in the future', E_USER_DEPRECATED);
+        }
         $this->defaultException = $defaultException;
     }
 


### PR DESCRIPTION
…xceptions

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #22 
| Documentation   | -
| License         | MIT


#### What's in this PR?

deprecate setting exceptions that violate the client contract. 