### PR TITLE
[WIP] Enhancement: Implement StrictClient

### DIFF
--- a/spec/Exception/RequestMismatchExceptionSpec.php
+++ b/spec/Exception/RequestMismatchExceptionSpec.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace spec\Http\Mock\Exception;
+
+use Http\Mock\Exception\RequestMismatchException;
+use Http\Mock\Exception\UnexpectedRequestException;
+use Http\Mock\StrictClient;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+
+class RequestMismatchExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RequestMismatchException::class);
+    }
+
+    function it_is_runtime_exception()
+    {
+        $this->shouldHaveType(\RuntimeException::class);
+    }
+
+    function it_can_be_created_from_matcher_exception()
+    {
+        $exception = new \Exception('Hmm');
+
+        $this->beConstructedThrough('fromMatcherException', [
+            $exception,
+        ]);
+
+        $this->shouldHaveType(RequestMismatchException::class);
+        $this->getMessage()->shouldReturn('Expected a different request to be sent.');
+        $this->getPrevious()->shouldReturn($exception);
+    }
+
+    function it_can_be_created_with_create()
+    {
+        $this->beConstructedThrough('create');
+
+        $this->shouldHaveType(RequestMismatchException::class);
+        $this->getMessage()->shouldReturn('Expected a different request to be sent.');
+    }
+}

--- a/spec/Exception/UnexpectedRequestExceptionSpec.php
+++ b/spec/Exception/UnexpectedRequestExceptionSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace spec\Http\Mock\Exception;
+
+use Http\Mock\Exception\UnexpectedRequestException;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+
+class UnexpectedRequestExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UnexpectedRequestException::class);
+    }
+
+    function it_is_runtime_exception()
+    {
+        $this->shouldHaveType(\RuntimeException::class);
+    }
+
+    function it_can_be_created_from_request(RequestInterface $request)
+    {
+        $this->beConstructedThrough('fromRequest', [
+            $request,
+        ]);
+
+        $this->shouldHaveType(UnexpectedRequestException::class);
+        $this->getMessage()->shouldReturn('Did not expect request to be sent');
+        $this->getRequest()->shouldReturn($request->getWrappedObject());
+    }
+}

--- a/spec/StrictClientSpec.php
+++ b/spec/StrictClientSpec.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace spec\Http\Mock;
+
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Http\Message\RequestMatcher;
+use Http\Message\ResponseFactory;
+use Http\Mock\Client;
+use Http\Mock\Exception\RequestMismatchException;
+use Http\Mock\Exception\UnexpectedRequestException;
+use Http\Mock\StrictClient;
+use PhpSpec\Matcher\MatcherInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @mixin StrictClient
+ */
+class StrictClientSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(StrictClient::class);
+    }
+
+    function it_is_an_http_client()
+    {
+        $this->shouldImplement(HttpClient::class);
+    }
+
+    function it_is_an_async_http_client()
+    {
+        $this->shouldImplement(HttpAsyncClient::class);
+    }
+
+    function it_throws_when_no_matchers_have_been_configured(RequestInterface $request)
+    {
+        $this
+            ->shouldThrow(UnexpectedRequestException::fromRequest($request->getWrappedObject()))
+            ->duringSendRequest($request);
+    }
+
+    function it_throws_when_next_request_matcher_throws_exception(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
+        $exception = new \Exception('Failed asserting that request method is "POST", got "GET" instead.');
+
+        $matcher->matches($request)->willThrow($exception);
+
+        $this->on($matcher, $response);
+
+        $this
+            ->shouldThrow(RequestMismatchException::fromMatcherException($exception))
+            ->duringSendRequest($request);
+    }
+
+    function it_throws_when_next_request_matcher_does_not_match_request(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
+        $matcher->matches($request)->willReturn(false);
+
+        $this->on($matcher, $response);
+
+        $this
+            ->shouldThrow(RequestMismatchException::create())
+            ->duringSendRequest($request);
+    }
+
+    function it_throws_configured_exception_when_next_request_matcher_matches_request(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
+        $exception = new \Exception('Sending the request failed because of a network error');
+
+        $matcher->matches($request)->willReturn(true);
+
+        $this->on($matcher, $exception);
+
+        $this
+            ->shouldThrow($exception)
+            ->duringSendRequest($request);
+    }
+
+    function it_returns_configured_request_when_next_request_matcher_matches_request(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
+        $matcher->matches($request)->willReturn(true);
+
+        $this->on($matcher, $response);
+
+        $this->sendRequest($request)->shouldReturn($response);
+    }
+
+    function it_calls_callable_with_request_as_argument_when_matcher_returns_true(
+        RequestMatcher $matcher,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
+        $matcher->matches($request)->willReturn(true);
+
+        $this->on(
+            $matcher,
+            function(RequestInterface $request) use ($response) {
+                return $response->getWrappedObject();
+            }
+        );
+
+        $this->sendRequest($request)->shouldReturn($response);
+    }
+
+    function it_has_completed_sequence_when_no_matches_have_been_configured()
+    {
+        $this->hasCompletedSequence()->shouldReturn(true);
+    }
+
+    function it_has_not_completed_sequence_when_not_all_expected_requests_have_been_sent(
+        RequestMatcher $firstMatcher,
+        RequestInterface $firstRequest,
+        ResponseInterface $firstResponse,
+        RequestMatcher $secondMatcher,
+        RequestInterface $secondRequest,
+        ResponseInterface $secondResponse
+    ) {
+        $firstMatcher->matches($firstRequest)->willReturn(true);
+
+        $this->on($firstMatcher, $firstResponse);
+
+        $secondMatcher->matches($secondRequest)->willReturn(true);
+
+        $this->on($secondMatcher, $secondResponse);
+
+        $this->sendRequest($firstRequest);
+
+        $this->hasCompletedSequence()->shouldReturn(false);
+    }
+
+    function it_has_completed_sequence_when_all_expected_requests_have_been_sent(
+        RequestMatcher $firstMatcher,
+        RequestInterface $firstRequest,
+        ResponseInterface $firstResponse,
+        RequestMatcher $secondMatcher,
+        RequestInterface $secondRequest,
+        ResponseInterface $secondResponse
+    ) {
+        $firstMatcher->matches($firstRequest)->willReturn(true);
+
+        $this->on($firstMatcher, $firstResponse);
+
+        $secondMatcher->matches($secondRequest)->willReturn(true);
+
+        $this->on($secondMatcher, $secondResponse);
+
+        $this->sendRequest($firstRequest);
+        $this->sendRequest($secondRequest);
+
+        $this->hasCompletedSequence()->shouldReturn(true);
+    }
+}

--- a/src/Exception/RequestMismatchException.php
+++ b/src/Exception/RequestMismatchException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Http\Mock\Exception;
+
+class RequestMismatchException extends \RuntimeException
+{
+    /**
+     * @param \Exception $exception
+     *
+     * @return self
+     */
+    public static function fromMatcherException(\Exception $exception)
+    {
+        return new self(
+            'Expected a different request to be sent.',
+            0,
+            $exception
+        );
+    }
+
+    /**
+     * @return self
+     */
+    public static function create()
+    {
+        return new self('Expected a different request to be sent.');
+    }
+}

--- a/src/Exception/UnexpectedRequestException.php
+++ b/src/Exception/UnexpectedRequestException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Http\Mock\Exception;
+
+use Psr\Http\Message\RequestInterface;
+
+class UnexpectedRequestException extends \RuntimeException
+{
+    /**
+     * @var RequestInterface|null
+     */
+    private $request;
+
+    /**
+     * @param RequestInterface $request
+     *
+     * @return self
+     */
+    public static function fromRequest(RequestInterface $request)
+    {
+        $instance = new self('Did not expect request to be sent');
+
+        $instance->request = $request;
+
+        return $instance;
+    }
+
+    /**
+     * @return RequestInterface|null
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/src/StrictClient.php
+++ b/src/StrictClient.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Http\Mock;
+
+use Http\Client\Common\HttpAsyncClientEmulator;
+use Http\Client\Common\VersionBridgeClient;
+use Http\Client\Exception;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Http\Message\RequestMatcher;
+use Http\Mock\Exception\RequestMismatchException;
+use Http\Mock\Exception\UnexpectedRequestException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * An implementation of the HTTP client that is useful for automated tests.
+ *
+ * This mock expects requests to be sent in a sequence and returns responses or throws exceptions as configured.
+ *
+ * @author Andreas Möller <am@localheinz.com>
+ */
+class StrictClient implements HttpClient, HttpAsyncClient
+{
+    use HttpAsyncClientEmulator;
+    use VersionBridgeClient;
+
+    /**
+     * @var array
+     */
+    private $configuredSequence = [];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UnexpectedRequestException
+     * @throws RequestMismatchException
+     */
+    public function doSendRequest(RequestInterface $request)
+    {
+        $next = array_shift($this->configuredSequence);
+
+        if (null === $next) {
+            throw UnexpectedRequestException::fromRequest($request);
+        }
+
+        /** @var RequestMatcher $matcher */
+        $matcher = $next['matcher'];
+
+        try {
+            $isMatch = $matcher->matches($request);
+        } catch (\Exception $exception) {
+            throw RequestMismatchException::fromMatcherException($exception);
+        }
+
+        if (false === $isMatch) {
+            throw RequestMismatchException::create();
+        }
+
+        /** @var callable $callable */
+        $callable = $next['callable'];
+
+        return $callable($request);
+    }
+
+    /**
+     * Adds an exception to be thrown or response to be returned for the next request
+     * expected to be sent in a sequence of requests.
+     *
+     * For more complex logic, pass a callable as $result. The method is given
+     * the request and MUST either return a ResponseInterface or throw an
+     * exception that implements the PSR-18 / HTTPlug exception interface.
+     *
+     * @param ResponseInterface|Exception|ClientExceptionInterface|callable $result
+     */
+    public function on(RequestMatcher $requestMatcher, $result)
+    {
+        $callable = null;
+
+        switch (true) {
+            case is_callable($result):
+                $callable = $result;
+
+                break;
+            case $result instanceof ResponseInterface:
+                $callable = function () use ($result) {
+                    return $result;
+                };
+
+                break;
+            case $result instanceof \Exception:
+                $callable = function () use ($result) {
+                    throw $result;
+                };
+
+                break;
+            default:
+                throw new \InvalidArgumentException('Result must be either a response, an exception, or a callable');
+        }
+
+        $this->configuredSequence[] = [
+            'matcher' => $requestMatcher,
+            'callable' => $callable,
+        ];
+    }
+
+    /**
+     * Returns true when the configured sequence of requests and responses (or exceptions)
+     * has been completed, i.e., the queue of configured results has been exhausted.
+     *
+     * @return bool
+     */
+    public function hasCompletedSequence()
+    {
+        return 0 === count($this->configuredSequence);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #41 
| Documentation   | todo
| License         | MIT

#### What's in this PR?

This PR

* [x] introduces a `StrictClient` which allows configuration of a sequence of matchers, and which will throw an exception when a request was sent that was not expected

#### Example Usage
##### Without configured sequence

```php
<?php

use Http\Mock\StrictClient;
use Nyholm\Psr7\Request;

$httpClient = new StrictClient();

var_dump($httpClient->hasCompletedSequence()); // true

// UnexpectedRequestException will be thrown
$httpClient->sendRequest(new Request(
    'GET',
    '/foo/bar'
));
```

##### With configured sequence and an unexpected additional request

```php
<?php

use Http\Message\RequestMatcher\CallbackRequestMatcher;
use Http\Mock\StrictClient;
use Nyholm\Psr7\Request;
use Nyholm\Psr7\Response;
use Psr\Http\Message\RequestInterface;

$httpClient = new StrictClient();

var_dump($httpClient->hasCompletedSequence()); // true

$httpClient->on(
    new CallbackRequestMatcher(static function (RequestInterface $request): bool {
        return 'POST' === $request->getMethod() && '/foo/bar' === (string) $request->getUri();
    }),
    new Response(
        200,
        [],
        'Sounds good!'
    )
);

var_dump($httpClient->hasCompletedSequence()); // false

$httpClient->sendRequest(new Request(
    'POST',
    '/foo/bar'
));

var_dump($httpClient->hasCompletedSequence()); // true

// UnexpectedRequestException will be thrown
$httpClient->sendRequest(new Request(
    'POST',
    '/foo/bar'
));
```

##### With configured sequence and an unexpected request

```php
<?php

use Http\Message\RequestMatcher\CallbackRequestMatcher;
use Http\Mock\StrictClient;
use Nyholm\Psr7\Request;
use Nyholm\Psr7\Response;
use Psr\Http\Message\RequestInterface;

$httpClient = new StrictClient();

var_dump($httpClient->hasCompletedSequence()); // true

$httpClient->on(
    new CallbackRequestMatcher(static function (RequestInterface $request): bool {
        return 'POST' === $request->getMethod() && '/foo/bar' === (string) $request->getUri();
    }),
    new Response(
        200,
        [],
        'Sounds good!'
    )
);

var_dump($httpClient->hasCompletedSequence()); // false

$httpClient->sendRequest(new Request(
    'POST',
    '/foo/bar'
));

var_dump($httpClient->hasCompletedSequence()); // true

// UnexpectedRequestException will be thrown
$httpClient->sendRequest(new Request(
    'GET',
    '/foo/bar'
));
```

##### With configured sequence, but not all requests have been sent yet 

```php
<?php

use Http\Message\RequestMatcher\CallbackRequestMatcher;
use Http\Mock\StrictClient;
use Nyholm\Psr7\Request;
use Nyholm\Psr7\Response;
use Psr\Http\Message\RequestInterface;

$httpClient = new StrictClient();

var_dump($httpClient->hasCompletedSequence()); // true

$httpClient->on(
    new CallbackRequestMatcher(static function (RequestInterface $request): bool {
        return 'POST' === $request->getMethod() && '/foo/bar' === (string) $request->getUri();
    }),
    new Response(
        200,
        [],
        'Sounds good!'
    )
);

$httpClient->on(
    new CallbackRequestMatcher(static function (RequestInterface $request): bool {
        return 'GET' === $request->getMethod() && '/foo/bar' === (string) $request->getUri();
    }),
    new Response(
        400,
        [],
        'Now is not a good time'
    )
);

var_dump($httpClient->hasCompletedSequence()); // false

$httpClient->sendRequest(new Request(
    'POST',
    '/foo/bar'
));

var_dump($httpClient->hasCompletedSequence()); // false
```

##### With configured sequence and all requests have been sent in correct order

```php
<?php

use Http\Message\RequestMatcher\CallbackRequestMatcher;
use Http\Mock\StrictClient;
use Nyholm\Psr7\Request;
use Nyholm\Psr7\Response;
use Psr\Http\Message\RequestInterface;

$httpClient = new StrictClient();

var_dump($httpClient->hasCompletedSequence()); // true

$httpClient->on(
    new CallbackRequestMatcher(static function (RequestInterface $request): bool {
        return 'POST' === $request->getMethod() && '/foo/bar' === (string) $request->getUri();
    }),
    new Response(
        200,
        [],
        'Sounds good!'
    )
);

$httpClient->on(
    new CallbackRequestMatcher(static function (RequestInterface $request): bool {
        return 'GET' === $request->getMethod() && '/foo/bar' === (string) $request->getUri();
    }),
    new Response(
        400,
        [],
        'Now is not a good time'
    )
);

var_dump($httpClient->hasCompletedSequence()); // false

$httpClient->sendRequest(new Request(
    'POST',
    '/foo/bar'
));

var_dump($httpClient->hasCompletedSequence()); // false

$httpClient->sendRequest(new Request(
    'GET',
    '/foo/bar'
));

var_dump($httpClient->hasCompletedSequence()); // true
``` 

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)