### PR TITLE
Enhancement: Extract method which ensures result is or converts it to callable

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -141,26 +141,20 @@ class Client implements HttpClient, HttpAsyncClient
     {
         switch (true) {
             case is_callable($result):
-                $callable = $result;
-
-                break;
+                return $result;
             case $result instanceof ResponseInterface:
-                $callable = function () use ($result) {
+                return function () use ($result) {
                     return $result;
                 };
 
                 break;
             case $result instanceof \Exception:
-                $callable = function () use ($result) {
+                return function () use ($result) {
                     throw $result;
                 };
-
-                break;
             default:
                 throw new \InvalidArgumentException('Result must be either a response, an exception, or a callable');
         }
-
-        return $callable;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -122,8 +122,23 @@ class Client implements HttpClient, HttpAsyncClient
      */
     public function on(RequestMatcher $requestMatcher, $result)
     {
-        $callable = null;
+        $callable = self::makeCallable($result);
 
+        $this->conditionalResults[] = [
+            'matcher' => $requestMatcher,
+            'callable' => $callable,
+        ];
+    }
+
+    /**
+     * @param ResponseInterface|Exception|ClientExceptionInterface|callable $result
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return callable
+     */
+    private static function makeCallable($result)
+    {
         switch (true) {
             case is_callable($result):
                 $callable = $result;
@@ -144,10 +159,8 @@ class Client implements HttpClient, HttpAsyncClient
             default:
                 throw new \InvalidArgumentException('Result must be either a response, an exception, or a callable');
         }
-        $this->conditionalResults[] = [
-            'matcher' => $requestMatcher,
-            'callable' => $callable,
-        ];
+
+        return $callable;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -139,22 +139,23 @@ class Client implements HttpClient, HttpAsyncClient
      */
     private static function makeCallable($result)
     {
-        switch (true) {
-            case is_callable($result):
-                return $result;
-            case $result instanceof ResponseInterface:
-                return function () use ($result) {
-                    return $result;
-                };
-
-                break;
-            case $result instanceof \Exception:
-                return function () use ($result) {
-                    throw $result;
-                };
-            default:
-                throw new \InvalidArgumentException('Result must be either a response, an exception, or a callable');
+        if (is_callable($result)) {
+            return $result;
         }
+
+        if ($result instanceof ResponseInterface) {
+            return function () use ($result) {
+                return $result;
+            };
+        }
+
+        if ($result instanceof \Exception) {
+            return function () use ($result) {
+                throw $result;
+            };
+        }
+
+        throw new \InvalidArgumentException('Result must be either a response, an exception, or a callable');
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

#### What's in this PR?

This PR

* [x] extracts a method which ensures that a result is - or converts it to - a callable
* [x] returns early
* [x] uses `if` instead of `switch`

#### Why?

This greatly improves the legibility (in my opinion).
