### PR TITLE
This package also provides a PSR-18 client implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     },
     "provide": {
         "php-http/async-client-implementation": "1.0",
-        "php-http/client-implementation": "1.0"
+        "php-http/client-implementation": "1.0",
+        "psr/http-client-implementation": "1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | not really
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #38
| License         | MIT

#### What's in this PR?
Explicitely tell in the composer.json file that this package provides a psr/http-client-implementation

#### Why?
Because of PSR-18 and packages (such as libs that needs to test their stuff) that requires an implem for an http client.

PR made against the upgrade-v2 branch as mentionned in https://github.com/php-http/mock-client/issues/38#issuecomment-466626548

#### Checklist
- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Added the `psr/http-client-implementation` in the `provide` section