### PR TITLE
Reset should not trigger setDefaultException error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.4.0 -
 
+### Fixed
+- `reset()` should not trigger `setDefaultException` error condition
+
+### Breaking
 - drop support for PHP 5 and 7.0
 
 ## 1.3.1 - 2019-11-06

--- a/src/Client.php
+++ b/src/Client.php
@@ -176,7 +176,7 @@ class Client implements HttpClient, HttpAsyncClient
      */
     public function setDefaultException(\Exception $defaultException = null)
     {
-        if (!$defaultException instanceof Exception) {
+        if ($defaultException !== null && !$defaultException instanceof Exception) {
             @trigger_error('Clients may only throw exceptions of type '.Exception::class.'. Setting an exception of class '.get_class($defaultException).' will not be possible anymore in the future', E_USER_DEPRECATED);
         }
         $this->defaultException = $defaultException;

--- a/src/Client.php
+++ b/src/Client.php
@@ -176,7 +176,7 @@ class Client implements HttpClient, HttpAsyncClient
      */
     public function setDefaultException(\Exception $defaultException = null)
     {
-        if ($defaultException !== null && !$defaultException instanceof Exception) {
+        if (null !== $defaultException && !$defaultException instanceof Exception) {
             @trigger_error('Clients may only throw exceptions of type '.Exception::class.'. Setting an exception of class '.get_class($defaultException).' will not be possible anymore in the future', E_USER_DEPRECATED);
         }
         $this->defaultException = $defaultException;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/php-http/mock-client/issues/49
| License         | MIT


#### What's in this PR?

Fixes `reset` triggering `setDefaultException` error


#### Why?

We should not trigger our own error conditions


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
