### PR TITLE
have the mock client provide the PSR client implementation as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.5.0 - 2021-08-25
+
+### Changed
+
+- Provide `psr/http-client-implementation`
+- Drop support for `php-http/httplug: 1.*` to be sure to implement a version of the client interface that implements the PSR.
 
 ## 1.4.1 - 2020-07-14
 

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "php-http/client-common": "^1.9 || ^2.0",
+        "php-http/client-common": "^2.0",
         "php-http/discovery": "^1.0",
-        "php-http/httplug": "^1.0 || ^2.0",
+        "php-http/httplug": "^2.0",
         "php-http/message-factory": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
@@ -28,7 +28,8 @@
     },
     "provide": {
         "php-http/async-client-implementation": "1.0",
-        "php-http/client-implementation": "1.0"
+        "php-http/client-implementation": "1.0",
+        "psr/http-client-implementation": "1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^5.1 || ^6.0"
@@ -38,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.4-dev"
+            "dev-master": "1.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
We need to bump httplug to version 2 because version 1 did not implement
the PSR interface. Version 2 implements both the php-http interface as
well as the PSR interface.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #56
| Documentation   | The documentation already assumes that this has happened...
| License         | MIT


#### What's in this PR?

Have the mock client provide the PSR client implementation as well.


#### Why?

This was intended but went under. We have to jump to HTTPlug 2.0 as that has the php-http client interface extend the PSR interface.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

