### PR TITLE
 Remove dependency on php-http/message-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php-http/client-common": "^2.0",
         "php-http/discovery": "^1.0",
         "php-http/httplug": "^2.0",
-        "php-http/message-factory": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | 
| Documentation   | 
| License         | MIT

`php-http/message-factory` is not required anymore. this package is also deprecated and replaced by `psr/http-factory`. 
