### PR TITLE
test that mock client can discover a message factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Change Log
 
-## 1.5.2 - 2023-05-23
+## 1.6.0 - 2023-05-21
+
+### Fixed
+
+- We actually did fallback to the legacy message factory discovery so 1.5.2 is broken.
+  Changed to use PSR 17 factory discovery.
+  If you allow the composer plugin of `php-http/discovery`, things will work out of the box.
+  When disabled and you do not have a PSR-17 factory installed, you will need to explicitly require one, e.g. `nyholm/psr7`.
+
+## 1.5.2 - 2023-05-17
+
+**Broken, use 1.6.0 instead**
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
         "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "php-http/client-common": "^2.0",
-        "php-http/discovery": "^1.0",
+        "php-http/discovery": "^1.16",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",
         "psr/http-factory-implementation": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php-http/discovery": "^1.0",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
         "symfony/polyfill-php80": "^1.17"
     },
@@ -36,7 +36,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "php-http/discovery": false
+            "php-http/discovery": true
         }
     },
     "autoload": {

--- a/spec/ClientSpec.php
+++ b/spec/ClientSpec.php
@@ -22,6 +22,9 @@ class ClientSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType(Client::class);
+
+        // make sure the client is also instantiable without arguments
+        new Client();
     }
 
     function it_is_an_http_client()

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ use Http\Client\Exception;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Message\RequestMatcher;
 use Http\Message\ResponseFactory;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -72,7 +73,7 @@ class Client implements HttpClient, HttpAsyncClient
             );
         }
 
-        $this->responseFactory = $responseFactory ?: MessageFactoryDiscovery::find();
+        $this->responseFactory = $responseFactory ?: Psr17FactoryDiscovery::findResponseFactory();
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #64
| Documentation   | -
| License         | MIT


#### What's in this PR?

Have mock client discover the PSR-17 factory rather than the legacy httplug message factory.