### PR TITLE
Make compatible with PHP 8.4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -204,7 +204,7 @@ class Client implements HttpClient, HttpAsyncClient
      *
      * If both a default exception and a default response are set, the exception will be thrown.
      */
-    public function setDefaultException(\Exception $defaultException = null)
+    public function setDefaultException(?\Exception $defaultException = null)
     {
         if (null !== $defaultException && !$defaultException instanceof Exception) {
             @trigger_error('Clients may only throw exceptions of type '.Exception::class.'. Setting an exception of class '.get_class($defaultException).' will not be possible anymore in the future', E_USER_DEPRECATED);
@@ -223,7 +223,7 @@ class Client implements HttpClient, HttpAsyncClient
     /**
      * Sets the default response to be returned when the list of added exceptions and responses is exhausted.
      */
-    public function setDefaultResponse(ResponseInterface $defaultResponse = null)
+    public function setDefaultResponse(?ResponseInterface $defaultResponse = null)
     {
         $this->defaultResponse = $defaultResponse;
     }


### PR DESCRIPTION
> Http\Mock\Client::setDefaultException(): Implicitly marking parameter $defaultException as nullable is deprecated, the explicit nullable type must be used instead

> Http\Mock\Client::setDefaultResponse(): Implicitly marking parameter $defaultResponse as nullable is deprecated, the explicit nullable type must be used instead